### PR TITLE
Fix folder fragment not shown except the first time for APIs below 23 (Close #5 ).

### DIFF
--- a/app/src/main/java/com/example/blah/mobilestudio/Activities/MainActivity.java
+++ b/app/src/main/java/com/example/blah/mobilestudio/Activities/MainActivity.java
@@ -100,7 +100,7 @@ public class MainActivity extends AppCompatActivity implements FolderStructureFr
 
     @Override
     public void onBackPressed() {
-        if (getFragmentManager().getBackStackEntryCount() > 0 ){
+        if (getFragmentManager().getBackStackEntryCount() > 0) {
             getFragmentManager().popBackStack();
         } else {
             super.onBackPressed();
@@ -196,18 +196,35 @@ public class MainActivity extends AppCompatActivity implements FolderStructureFr
         return super.onCreateOptionsMenu(menu);
     }
 
+    /**
+     * Call commitAllowingStateLoss() instead of commit().
+     * Please refer to http://stackoverflow.com/questions/7575921/illegalstateexception
+     * -can-not-perform-this-action-after-onsaveinstancestate-wit
+     */
     private void openFile(String filePath) {
-        FolderStructureFragment folderStructureFragment = new FolderStructureFragment();
-        Bundle b = new Bundle();
-        b.putString(FolderStructureFragment.FILE_PATH, filePath);
-        folderStructureFragment.setOnClickListener(this);
-        folderStructureFragment.setArguments(b);
+        FolderStructureFragment folderStructureFragment = (FolderStructureFragment) getSupportFragmentManager().findFragmentById(R.id.explorer_fragment);
 
-        getFragmentManager().beginTransaction().replace(R.id.explorer_fragment, folderStructureFragment).commit();
+        if (folderStructureFragment != null) {
+            Bundle b = folderStructureFragment.getArguments();
+            b.putString(FolderStructureFragment.FILE_PATH, filePath);
+            folderStructureFragment.setOnClickListener(this);
+            getSupportFragmentManager().beginTransaction()
+                    .detach(folderStructureFragment)
+                    .attach(folderStructureFragment)
+                    .commitAllowingStateLoss();
+        } else {
+            folderStructureFragment = new FolderStructureFragment();
+            Bundle b = new Bundle();
+            b.putString(FolderStructureFragment.FILE_PATH, filePath);
+            folderStructureFragment.setOnClickListener(this);
+            folderStructureFragment.setArguments(b);
+            getSupportFragmentManager().beginTransaction().replace(R.id.explorer_fragment, folderStructureFragment).commitAllowingStateLoss();;
+
+        }
     }
 
     private void highlightFIle(String filePath) {
-        FolderStructureFragment folderFragment = (FolderStructureFragment) getFragmentManager().findFragmentById(R.id.explorer_fragment);
+        FolderStructureFragment folderFragment = (FolderStructureFragment) getSupportFragmentManager().findFragmentById(R.id.explorer_fragment);
         folderFragment.highlightFile(filePath);
     }
 
@@ -215,6 +232,7 @@ public class MainActivity extends AppCompatActivity implements FolderStructureFr
         //Horizontal Breadcrumb reset
         breadFragment = (BreadcrumbFragment) getFragmentManager().findFragmentById(R.id.topBreadFragment);
         breadFragment.currentPath = filePath;
+
         breadFragment.setOnClickListener(this);
         getFragmentManager().beginTransaction().replace(R.id.topBreadFragment, breadFragment).commit();
 

--- a/app/src/main/java/com/example/blah/mobilestudio/fileTreeView/FolderStructureFragment.java
+++ b/app/src/main/java/com/example/blah/mobilestudio/fileTreeView/FolderStructureFragment.java
@@ -1,18 +1,14 @@
 package com.example.blah.mobilestudio.fileTreeView;
 
 import android.app.Activity;
-import android.app.Fragment;
 import android.content.Context;
-import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-
 import com.example.blah.mobilestudio.R;
-import com.example.blah.mobilestudio.fileTreeView.FileNodeViewHolder;
-import com.example.blah.mobilestudio.fileTreeView.FileTreeView;
 import com.example.blah.mobilestudio.treeview.TreeNode;
 
 import java.io.File;
@@ -72,21 +68,8 @@ public class FolderStructureFragment extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (context instanceof Activity) {
-                doAttach((Activity) context);
-            }
-        }
+        doAttach((Activity) context);
     }
-
-    @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            doAttach(activity);
-        }
-    }
-
 
     private void doAttach(Activity activity) {
         try {
@@ -97,11 +80,16 @@ public class FolderStructureFragment extends Fragment {
         }
     }
 
+    /**
+     * Call super.onSaveInstanceState() in the end.
+     * Please refer to http://stackoverflow.com/questions/7575921/illegalstateexception
+     * -can-not-perform-this-action-after-onsaveinstancestate-wit
+     */
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
         outState.putString("tState", tView.getSaveState());
         outState.putString("selectedFilePath", tView.getSelectedFilePath());
+        super.onSaveInstanceState(outState);
     }
 
     /**


### PR DESCRIPTION
Hi, @marklynx I fix the issue #5 
Can you do a quick review.
I've tried to reuse the fragment by `detache` and `attach` again.
But still `onStart()` didn't get called except the first time.
So, I changed to `android.support.v4.app.Fragment` and it works fine on APIs below 23 now.
